### PR TITLE
Init Question Delete Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ When you run tests, use the following:
 cargo test -- --test-threads=1
 ```
 
+If tests are failing and you see an error there are "too many open files",
+especially on Linux:
+
+```bash
+ulimit -n 10000
+```
+
 ### End to End Testing
 
 Working with Python and [RobotFrameWork](https://robotframework.org) as I am familiar with this tool.

--- a/backend/src/routes/create_questions.rs
+++ b/backend/src/routes/create_questions.rs
@@ -114,13 +114,14 @@ pub async fn create_new_questions(
 
             let it: &SurrealQuestionMC = &res[0];
 
+            // Cut this out of workflow as it isn't being used
             // -- Save Question ID into Quiz
-            let _: Option<SurrealRecord> = db
-                .client
-                .update(&quiz_id)
-                .patch(PatchOp::add("/questions_mc", it.id.clone()))
-                .await
-                .map_err(|e| CreateQuestionError::UnexpectedError(anyhow::anyhow!(e)))?;
+            // let _: Option<SurrealRecord> = db
+            //     .client
+            //     .update(&quiz_id)
+            //     .patch(PatchOp::add("/questions_mc", it.id.clone()))
+            //     .await
+            //     .map_err(|e| CreateQuestionError::UnexpectedError(anyhow::anyhow!(e)))?;
 
             serde_json::to_value(it)
                 .map_err(|e| CreateQuestionError::UnexpectedError(anyhow::anyhow!(e)))?

--- a/backend/src/routes/destroy_question.rs
+++ b/backend/src/routes/destroy_question.rs
@@ -7,7 +7,7 @@ use actix_web::http::{header::ContentType, StatusCode};
 use actix_web::web;
 use actix_web::{HttpRequest, HttpResponse, ResponseError};
 use anyhow::Context;
-use models::questions::SurrealQuestionMC;
+use models::questions::{GenericQuestionData, SurrealGenericQuestionData, SurrealQuestionMC};
 use models::{model_errors::ModelErrors, quiz::SurrealQuiz};
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::{thing, Thing};
@@ -96,7 +96,7 @@ pub async fn destroy_my_quest(
         .map_err(|err| DestroyQuestError::ValidationError(err))?;
 
     // Checking  -- Error returned from database indicates no ID exists.
-    let surreal_quest: Option<SurrealQuestionMC> = db
+    let surreal_quest: Option<SurrealGenericQuestionData> = db
         .client
         .select(&quest_id)
         .await

--- a/backend/src/routes/destroy_question.rs
+++ b/backend/src/routes/destroy_question.rs
@@ -1,5 +1,5 @@
-//! backend/src/routes/destroy_quiz.rs
-//! To delete a quiz and related questions from database.
+//! backend/src/routes/destroy_question.rs
+//! to delete a question from the database.
 use crate::error_chain_helper;
 use crate::session_wrapper::SessionWrapper;
 use crate::surrealdb_repo::Database;
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 // Errors
 #[derive(thiserror::Error)]
-pub enum DestroyQuizError {
+pub enum DestroyQuestError {
     #[error("{0}")]
     AuthorizationError(String),
     #[error("{0}")]
@@ -25,30 +25,30 @@ pub enum DestroyQuizError {
     UnexpectedError(#[from] anyhow::Error),
 }
 
-impl std::fmt::Debug for DestroyQuizError {
+impl std::fmt::Debug for DestroyQuestError {
     /// Custom implementation to display root cause of errors
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         error_chain_helper(self, f)
     }
 }
 
-impl ResponseError for DestroyQuizError {
+impl ResponseError for DestroyQuestError {
     fn error_response(&self) -> HttpResponse<actix_web::body::BoxBody> {
         match self {
-            DestroyQuizError::UnexpectedError(_) => {
+            DestroyQuestError::UnexpectedError(_) => {
                 HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
                     .insert_header(ContentType::json())
                     .json(serde_json::json!({"msg": "Unknown Error"}))
             }
-            DestroyQuizError::AuthorizationError(msg) => {
+            DestroyQuestError::AuthorizationError(msg) => {
                 HttpResponse::build(StatusCode::UNAUTHORIZED)
                     .insert_header(ContentType::json())
                     .json(serde_json::json!({ "msg": msg }))
             }
-            DestroyQuizError::OwnershipError(anywho) => HttpResponse::build(StatusCode::FORBIDDEN)
+            DestroyQuestError::OwnershipError(anywho) => HttpResponse::build(StatusCode::FORBIDDEN)
                 .insert_header(ContentType::json())
                 .json(serde_json::json!({ "msg": anywho.to_string() })),
-            DestroyQuizError::ValidationError(anywho) => {
+            DestroyQuestError::ValidationError(anywho) => {
                 HttpResponse::build(StatusCode::BAD_REQUEST)
                     .insert_header(ContentType::json())
                     .json(serde_json::json!({ "msg": anywho.to_string() }))
@@ -58,33 +58,33 @@ impl ResponseError for DestroyQuizError {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct QuizDestroyerQueryString {
-    quiz: String,
+pub struct QuestDestroyerQueryString {
+    quest: String,
 }
 
 /// TODO: Documentation
 #[tracing::instrument(name = "Request to Destroy User's Quiz by User", skip(db, session))]
-pub async fn destroy_my_quiz(
+pub async fn destroy_my_quest(
     req: HttpRequest,
     session: SessionWrapper,
     db: web::Data<Database>,
-    quiz: web::Query<QuizDestroyerQueryString>,
-) -> Result<HttpResponse, DestroyQuizError> {
+    quest: web::Query<QuestDestroyerQueryString>,
+) -> Result<HttpResponse, DestroyQuestError> {
     let some_user_id: Option<Uuid> = session
         .get_user_id()
-        .map_err(|_| DestroyQuizError::UnexpectedError(anyhow::anyhow!("A SessionGetError")))?;
+        .map_err(|_| DestroyQuestError::UnexpectedError(anyhow::anyhow!("A SessionGetError")))?;
 
     // Middleware should catch unauthorized users, but just in case
     let user_id: String = if let Some(id) = some_user_id {
         id.to_string()
     } else {
-        return Err(DestroyQuizError::AuthorizationError(
+        return Err(DestroyQuestError::AuthorizationError(
             "Session Token not found".to_string(),
         ));
     };
 
     // Decode Query String
-    let quiz_query_str: String = quiz.into_inner().quiz;
+    let quest_query_string: String = quest.into_inner().quest;
     let decoded_query_str: String = urlencoding::decode(&quiz_query_str)
         .expect("UTF-8")
         .into_owned();
@@ -92,27 +92,27 @@ pub async fn destroy_my_quiz(
     // If cannot be parsed, it cannot be in database
     let quiz_id: Thing = thing(&decoded_query_str)
         .context("Unable to parse query")
-        .map_err(|err| DestroyQuizError::ValidationError(err))?;
+        .map_err(|err| DestroyQuestError::ValidationError(err))?;
 
     // Checking  -- Error returned from database indicates no ID exists.
     let mut surreal_quiz: Option<SurrealQuiz> = db
         .client
         .select(&quiz_id)
         .await
-        .map_err(|err| DestroyQuizError::ValidationError(anyhow::anyhow!(err)))?;
+        .map_err(|err| DestroyQuestError::ValidationError(anyhow::anyhow!(err)))?;
 
     dbg!(&surreal_quiz);
 
     // Sanity checks
     match &surreal_quiz {
         None => {
-            return Err(DestroyQuizError::ValidationError(anyhow::anyhow!(
+            return Err(DestroyQuestError::ValidationError(anyhow::anyhow!(
                 "Quiz does not exist"
             )));
         }
         Some(qz) => {
             if qz.author_id != user_id {
-                return Err(DestroyQuizError::OwnershipError(anyhow::anyhow!(
+                return Err(DestroyQuestError::OwnershipError(anyhow::anyhow!(
                     "User does not own quiz"
                 )));
             }
@@ -126,7 +126,7 @@ pub async fn destroy_my_quiz(
         .client
         .delete(&quiz_id)
         .await
-        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+        .map_err(|err| DestroyQuestError::UnexpectedError(anyhow::anyhow!(err)))?;
     // Delete related questions
 
     // Delete from MC table
@@ -137,11 +137,11 @@ pub async fn destroy_my_quiz(
         .bind(("table", "questions_mc"))
         .bind(("user_id", user_id))
         .await
-        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+        .map_err(|err| DestroyQuestError::UnexpectedError(anyhow::anyhow!(err)))?;
 
     let quizzes: Vec<SurrealQuiz> = surreal_response
         .take(0)
-        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+        .map_err(|err| DestroyQuestError::UnexpectedError(anyhow::anyhow!(err)))?;
 
     Ok(HttpResponse::Ok().json(quizzes))
 }

--- a/backend/src/routes/destroy_quiz.rs
+++ b/backend/src/routes/destroy_quiz.rs
@@ -122,7 +122,7 @@ pub async fn destroy_my_quiz(
     dbg!(&surreal_quiz);
 
     // Delete Quiz
-    let _deleted_quiz: Option<SurrealQuiz> = db
+    let deleted_quiz: Option<SurrealQuiz> = db
         .client
         .delete(&quiz_id)
         .await
@@ -131,7 +131,7 @@ pub async fn destroy_my_quiz(
 
     // Delete from MC table
     let surreal_ql = "DELETE type::table($table) WHERE author_id = $user_id";
-    let mut surreal_response: surrealdb::Response = db
+    let surreal_response: surrealdb::Response = db
         .client
         .query(surreal_ql)
         .bind(("table", "questions_mc"))
@@ -139,9 +139,5 @@ pub async fn destroy_my_quiz(
         .await
         .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
 
-    let quizzes: Vec<SurrealQuiz> = surreal_response
-        .take(0)
-        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
-
-    Ok(HttpResponse::Ok().json(quizzes))
+    Ok(HttpResponse::Ok().json(deleted_quiz))
 }

--- a/backend/src/routes/destroy_quiz.rs
+++ b/backend/src/routes/destroy_quiz.rs
@@ -38,7 +38,7 @@ impl ResponseError for DestroyQuizError {
             DestroyQuizError::UnexpectedError(_) => {
                 HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
                     .insert_header(ContentType::json())
-                    .json(serde_json::json!({"msg": "Unknown Error"}))
+                    .json(serde_json::json!({"msg": "errUnknown Error"}))
             }
             DestroyQuizError::AuthorizationError(msg) => {
                 HttpResponse::build(StatusCode::UNAUTHORIZED)

--- a/backend/src/routes/destroy_quiz.rs
+++ b/backend/src/routes/destroy_quiz.rs
@@ -1,0 +1,139 @@
+//! backend/src/routes/get_quiz.rs
+//! To fetch quizzes for a user.
+use crate::error_chain_helper;
+use crate::session_wrapper::SessionWrapper;
+use crate::surrealdb_repo::Database;
+use actix_web::http::{header::ContentType, StatusCode};
+use actix_web::web;
+use actix_web::{HttpRequest, HttpResponse, ResponseError};
+use anyhow::Context;
+use models::{model_errors::ModelErrors, quiz::SurrealQuiz};
+use serde::{Deserialize, Serialize};
+use surrealdb::sql::{thing, Thing};
+use uuid::Uuid;
+
+// Errors
+#[derive(thiserror::Error)]
+pub enum DestroyQuizError {
+    #[error("{0}")]
+    AuthorizationError(String),
+    #[error("{0}")]
+    OwnershipError(#[source] anyhow::Error),
+    #[error("{0}")]
+    ValidationError(#[source] anyhow::Error),
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl std::fmt::Debug for DestroyQuizError {
+    /// Custom implementation to display root cause of errors
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_helper(self, f)
+    }
+}
+
+impl ResponseError for DestroyQuizError {
+    fn error_response(&self) -> HttpResponse<actix_web::body::BoxBody> {
+        match self {
+            DestroyQuizError::UnexpectedError(_) => {
+                HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .insert_header(ContentType::json())
+                    .json(serde_json::json!({"msg": "Unknown Error"}))
+            }
+            DestroyQuizError::AuthorizationError(msg) => {
+                HttpResponse::build(StatusCode::UNAUTHORIZED)
+                    .insert_header(ContentType::json())
+                    .json(serde_json::json!({ "msg": msg }))
+            }
+            DestroyQuizError::OwnershipError(anywho) => HttpResponse::build(StatusCode::FORBIDDEN)
+                .insert_header(ContentType::json())
+                .json(serde_json::json!({ "msg": anywho.to_string() })),
+            DestroyQuizError::ValidationError(anywho) => {
+                HttpResponse::build(StatusCode::BAD_REQUEST)
+                    .insert_header(ContentType::json())
+                    .json(serde_json::json!({ "msg": anywho.to_string() }))
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct QuizDestroyerQueryString {
+    quiz: String,
+}
+
+/// TODO: Documentation
+#[tracing::instrument(name = "Request to Destroy User's Quiz by User", skip(db, session))]
+pub async fn destroy_my_quiz(
+    req: HttpRequest,
+    session: SessionWrapper,
+    db: web::Data<Database>,
+    quiz: web::Query<QuizDestroyerQueryString>,
+) -> Result<HttpResponse, DestroyQuizError> {
+    let some_user_id: Option<Uuid> = session
+        .get_user_id()
+        .map_err(|_| DestroyQuizError::UnexpectedError(anyhow::anyhow!("A SessionGetError")))?;
+    dbg!(&some_user_id);
+
+    // Middleware should catch unauthorized users, but just in case
+    let user_id: String = if let Some(id) = some_user_id {
+        id.to_string()
+    } else {
+        return Err(DestroyQuizError::AuthorizationError(
+            "Session Token not found".to_string(),
+        ));
+    };
+
+    // Decode Query String
+    let quiz_query_str: String = quiz.into_inner().quiz;
+    let decoded_query_str: String = urlencoding::decode(&quiz_query_str)
+        .expect("UTF-8")
+        .into_owned();
+    let quiz_id: Thing = thing(&decoded_query_str).context("Unable to parse query")?;
+
+    let mut surreal_quiz: Option<SurrealQuiz> = db
+        .client
+        .select(&quiz_id)
+        .await
+        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+
+    // Sanity checks
+    match &surreal_quiz {
+        None => {
+            return Err(DestroyQuizError::ValidationError(anyhow::anyhow!(
+                "Quiz does not exist"
+            )));
+        }
+        Some(qz) => {
+            if qz.author_id != user_id {
+                return Err(DestroyQuizError::OwnershipError(anyhow::anyhow!(
+                    "User does not own quiz"
+                )));
+            }
+        }
+    }
+
+    // Delete Quiz
+    let deleted_quiz: Option<SurrealQuiz> = db
+        .client
+        .delete(&quiz_id)
+        .await
+        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+    // Delete related questions
+
+    // Delete from MC table
+    let surreal_ql = "DELETE type::table($table) WHERE author_id = $user_id";
+    let mut surreal_response: surrealdb::Response = db
+        .client
+        .query(surreal_ql)
+        .bind(("table", "questions_mc"))
+        .bind(("user_id", user_id))
+        .await
+        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+
+    let quizzes: Vec<SurrealQuiz> = surreal_response
+        .take(0)
+        .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
+
+    Ok(HttpResponse::Ok().json(quizzes))
+}

--- a/backend/src/routes/like_question.rs
+++ b/backend/src/routes/like_question.rs
@@ -2,6 +2,7 @@
 //! endpoint to toggle like status on a question.
 use actix_web::{HttpRequest, HttpResponse};
 
+// TODO: Finish Implementation
 #[tracing::instrument(name = "Request to Toggle Question Like Status")]
 pub async fn toggle_like(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().finish()

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -2,6 +2,7 @@
 mod create_questions;
 mod create_quiz;
 mod create_user;
+mod destroy_question;
 mod destroy_quiz;
 mod get_question;
 mod get_quiz;
@@ -13,6 +14,7 @@ mod user_logout;
 pub use create_questions::*;
 pub use create_quiz::*;
 pub use create_user::*;
+pub use destroy_question::*;
 pub use destroy_quiz::*;
 pub use get_question::*;
 pub use get_quiz::*;

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -2,6 +2,7 @@
 mod create_questions;
 mod create_quiz;
 mod create_user;
+mod destroy_quiz;
 mod get_question;
 mod get_quiz;
 mod health_check;
@@ -12,6 +13,7 @@ mod user_logout;
 pub use create_questions::*;
 pub use create_quiz::*;
 pub use create_user::*;
+pub use destroy_quiz::*;
 pub use get_question::*;
 pub use get_quiz::*;
 pub use health_check::*;

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -1,13 +1,7 @@
 //! backend/src/startup.rs
 //! Holds application level information and functions.
 use crate::{
-    authentication::AuthCookie,
-    configuration::AllSettings,
-    routes::{
-        check_login, create_new_questions, create_new_quiz, create_user, get_my_quizzes,
-        get_questions, health_check, user_login, user_logout,
-    },
-    surrealdb_repo::Database,
+    authentication::AuthCookie, configuration::AllSettings, routes::*, surrealdb_repo::Database,
 };
 use actix_cors::Cors;
 use actix_session::{config::PersistentSession, SessionMiddleware};
@@ -90,6 +84,7 @@ pub async fn run(
                     // This is for making and fetching quizzes
                     .route("/quiz-nexus", web::get().to(get_my_quizzes))
                     .route("/quiz-nexus", web::post().to(create_new_quiz))
+                    .route("/quiz-nexus", web::delete().to(destroy_my_quiz))
                     .route("/question-forge", web::get().to(get_questions))
                     .route("/question-forge", web::post().to(create_new_questions)),
                 // Below I think will be for making questions

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -86,7 +86,8 @@ pub async fn run(
                     .route("/quiz-nexus", web::post().to(create_new_quiz))
                     .route("/quiz-nexus", web::delete().to(destroy_my_quiz))
                     .route("/question-forge", web::get().to(get_questions))
-                    .route("/question-forge", web::post().to(create_new_questions)),
+                    .route("/question-forge", web::post().to(create_new_questions))
+                    .route("/question-forge", web::delete().to(destroy_my_quest)),
                 // Below I think will be for making questions
                 // .route("/query-forge", web::get().to(?)),
             )

--- a/backend/tests/api/destroy_question.rs
+++ b/backend/tests/api/destroy_question.rs
@@ -1,5 +1,5 @@
 //! backend/tests/api/destroy_quiz.rs
-use crate::utils::{spawn_app, CreateQuestions, CreateQuiz, DestroyQuiz, TestApp};
+use crate::utils::{spawn_app, CreateQuestions, CreateQuiz, DestroyQuestion, DestroyQuiz, TestApp};
 use models::{
     questions::{JsonQuestion, JsonQuestionMC, QuestionJsonPkg, SurrealQuestionMC},
     quiz::SurrealQuiz,
@@ -31,7 +31,7 @@ async fn cleanup_db(test_app: &TestApp) {
 }
 
 #[tokio::test]
-async fn test_user_delete_quiz_200() {
+async fn test_user_delete_quest_200() {
     // -- Arrange
     let test_app: TestApp = spawn_app().await;
 
@@ -55,7 +55,7 @@ async fn test_user_delete_quiz_200() {
     let quiz: SurrealQuiz = response.json().await.unwrap();
 
     // Creating Question!
-    let q1 = JsonQuestion::MultipleChoice(JsonQuestionMC {
+    let quest_json = JsonQuestion::MultipleChoice(JsonQuestionMC {
         question: String::from(
             "Which sorting algorithm has an average and worst-case time complexity of O(n log(n))?",
         ),
@@ -72,21 +72,23 @@ async fn test_user_delete_quiz_200() {
 
     let mut package: QuestionJsonPkg = QuestionJsonPkg {
         quiz_id: quiz.id.clone(),
-        question: q1,
+        question: quest_json,
     };
     let question_response: Response = test_app.post_create_questions(&package).await;
     assert!(question_response.status() == 201);
+    let surreal_quest_mc: SurrealQuestionMC = question_response.json().await.unwrap();
 
     // Setting up query param
-    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+    let query_param: String = urlencoding::encode(&surreal_quest_mc.id.to_raw()).to_string();
 
     // Act
-    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    let test_res: Response = test_app.destroy_question(query_param).await;
     assert!(test_res.status().as_u16() == 200);
 
     // Assert
+    // Make sure the quiz is OK
     let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
-    assert!(1 > actual.len());
+    assert!(0 < actual.len());
     let actual_quest: Vec<SurrealQuestionMC> = test_app
         .database
         .client
@@ -100,7 +102,7 @@ async fn test_user_delete_quiz_200() {
 }
 
 #[tokio::test]
-async fn test_anon_user_delete_quiz_401() {
+async fn test_anon_user_delete_quest_401() {
     // -- Arrange
     let test_app: TestApp = spawn_app().await;
 
@@ -123,8 +125,32 @@ async fn test_anon_user_delete_quiz_401() {
     assert!(response.status().is_success());
     let quiz: SurrealQuiz = response.json().await.unwrap();
 
+    // Creating Question!
+    let quest_json = JsonQuestion::MultipleChoice(JsonQuestionMC {
+        question: String::from(
+            "Which sorting algorithm has an average and worst-case time complexity of O(n log(n))?",
+        ),
+        hint: Some(String::from(
+            "This algorithm uses a divide-and-conquer strategy and is often implement recursively.",
+        )),
+        answer: String::from("Merge Sort"),
+        choices: vec![
+            String::from("Bubble Sort"),
+            String::from("Quick Sort"),
+            String::from("Selection Sort"),
+        ],
+    });
+
+    let mut package: QuestionJsonPkg = QuestionJsonPkg {
+        quiz_id: quiz.id.clone(),
+        question: quest_json,
+    };
+    let question_response: Response = test_app.post_create_questions(&package).await;
+    assert!(question_response.status() == 201);
+    let surreal_quest_mc: SurrealQuestionMC = question_response.json().await.unwrap();
+
     // Setting up query param
-    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+    let query_param: String = urlencoding::encode(&surreal_quest_mc.id.to_raw()).to_string();
 
     let log_out_response: Response = test_app
         .api_client
@@ -135,11 +161,16 @@ async fn test_anon_user_delete_quiz_401() {
     assert!(log_out_response.status().is_success());
 
     // Act
-    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    let test_res: Response = test_app.destroy_question(query_param).await;
     assert!(test_res.status().as_u16() == 401);
 
     // Assert
-    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    let actual: Vec<SurrealQuestionMC> = test_app
+        .database
+        .client
+        .select("questions_mc")
+        .await
+        .unwrap();
     assert!(1 == actual.len());
 
     // clean up database
@@ -147,7 +178,7 @@ async fn test_anon_user_delete_quiz_401() {
 }
 
 #[tokio::test]
-async fn test_other_user_delete_quiz_403() {
+async fn test_other_user_delete_quest_403() {
     // -- Arrange
     let test_app: TestApp = spawn_app().await;
 
@@ -196,8 +227,32 @@ async fn test_other_user_delete_quiz_403() {
     assert!(response.status().is_success());
     let quiz: SurrealQuiz = response.json().await.unwrap();
 
+    // Creating Question!
+    let quest_json = JsonQuestion::MultipleChoice(JsonQuestionMC {
+        question: String::from(
+            "Which sorting algorithm has an average and worst-case time complexity of O(n log(n))?",
+        ),
+        hint: Some(String::from(
+            "This algorithm uses a divide-and-conquer strategy and is often implement recursively.",
+        )),
+        answer: String::from("Merge Sort"),
+        choices: vec![
+            String::from("Bubble Sort"),
+            String::from("Quick Sort"),
+            String::from("Selection Sort"),
+        ],
+    });
+
+    let mut package: QuestionJsonPkg = QuestionJsonPkg {
+        quiz_id: quiz.id.clone(),
+        question: quest_json,
+    };
+    let question_response: Response = test_app.post_create_questions(&package).await;
+    assert!(question_response.status() == 201);
+    let surreal_quest_mc: SurrealQuestionMC = question_response.json().await.unwrap();
+
     // Setting up query param
-    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+    let query_param: String = urlencoding::encode(&surreal_quest_mc.id.to_raw()).to_string();
 
     let log_out_response: Response = test_app
         .api_client
@@ -215,11 +270,16 @@ async fn test_other_user_delete_quiz_403() {
     assert!(test_app_response.status().is_success());
 
     // Act
-    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    let test_res: Response = test_app.destroy_question(query_param).await;
     assert!(test_res.status().as_u16() == 403);
 
     // Assert
-    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    let actual: Vec<SurrealQuestionMC> = test_app
+        .database
+        .client
+        .select("questions_mc")
+        .await
+        .unwrap();
     assert!(1 == actual.len());
 
     // clean up database
@@ -227,7 +287,7 @@ async fn test_other_user_delete_quiz_403() {
 }
 
 #[tokio::test]
-async fn test_create_quiz_400() {
+async fn test_create_quest_400() {
     // -- Arrange
     let test_app: TestApp = spawn_app().await;
 
@@ -250,17 +310,46 @@ async fn test_create_quiz_400() {
     assert!(response.status().is_success());
     let quiz: SurrealQuiz = response.json().await.unwrap();
 
+    // Creating Question!
+    let quest_json = JsonQuestion::MultipleChoice(JsonQuestionMC {
+        question: String::from(
+            "Which sorting algorithm has an average and worst-case time complexity of O(n log(n))?",
+        ),
+        hint: Some(String::from(
+            "This algorithm uses a divide-and-conquer strategy and is often implement recursively.",
+        )),
+        answer: String::from("Merge Sort"),
+        choices: vec![
+            String::from("Bubble Sort"),
+            String::from("Quick Sort"),
+            String::from("Selection Sort"),
+        ],
+    });
+
+    let mut package: QuestionJsonPkg = QuestionJsonPkg {
+        quiz_id: quiz.id.clone(),
+        question: quest_json,
+    };
+    let question_response: Response = test_app.post_create_questions(&package).await;
+    assert!(question_response.status() == 201);
+    let surreal_quest_mc: SurrealQuestionMC = question_response.json().await.unwrap();
+
     // Setting up query param
-    // let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
-    let query_param: String = urlencoding::encode("quizzes:not-real-id-123").to_string();
+    // let query_param: String = urlencoding::encode(&surreal_quest_mc.id.to_raw()).to_string();
+    let query_param: String = urlencoding::encode("questions_mc:not-real-id-123").to_string();
 
     // Act
     // NOTE: Currently the DB returns an error that is converted to a 500.
-    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    let test_res: Response = test_app.destroy_question(query_param).await;
     assert!(test_res.status() == 400);
 
     // Assert
-    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    let actual: Vec<SurrealQuestionMC> = test_app
+        .database
+        .client
+        .select("questions_mc")
+        .await
+        .unwrap();
     dbg!(&actual);
     assert!(0 < actual.len());
 

--- a/backend/tests/api/destroy_question.rs
+++ b/backend/tests/api/destroy_question.rs
@@ -83,6 +83,7 @@ async fn test_user_delete_quest_200() {
 
     // Act
     let test_res: Response = test_app.destroy_question(query_param).await;
+    dbg!(&test_res);
     assert!(test_res.status().as_u16() == 200);
 
     // Assert
@@ -271,6 +272,7 @@ async fn test_other_user_delete_quest_403() {
 
     // Act
     let test_res: Response = test_app.destroy_question(query_param).await;
+    dbg!(&test_res);
     assert!(test_res.status().as_u16() == 403);
 
     // Assert

--- a/backend/tests/api/destroy_quiz.rs
+++ b/backend/tests/api/destroy_quiz.rs
@@ -1,0 +1,241 @@
+//! backend/tests/api/create_quiz.rs
+use crate::utils::{spawn_app, CreateQuiz, DestroyQuiz, TestApp};
+use models::quiz::SurrealQuiz;
+use reqwest::Response;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use surrealdb::sql::Thing;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SurrealRecord {
+    id: Thing,
+}
+
+#[tokio::test]
+async fn test_user_delete_quiz_200() {
+    // -- Arrange
+    let test_app: TestApp = spawn_app().await;
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+
+    // create user for testing
+    let mut test_app_response = test_app.create_new_test_user().await;
+    assert!(test_app_response.status().is_success());
+    // log in user
+    test_app_response = test_app.log_in_test_user().await;
+    assert!(test_app_response.status().is_success());
+
+    // Quiz Structure - Hopefully no questions starts and empty vector
+    let info: serde_json::Value = serde_json::json!({
+        "name": "Algorithms",
+        "description": "An algorithms quiz"
+    });
+    let response: Response = test_app.post_create_quiz(&info).await;
+    assert!(response.status().is_success());
+    let quiz: SurrealQuiz = response.json().await.unwrap();
+
+    // Setting up query param
+    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+
+    // Act
+    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    assert!(test_res.status().as_u16() == 200);
+
+    // Assert
+    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    assert!(1 > actual.len());
+
+    // Clean up
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_anon_user_delete_quiz_401() {
+    // -- Arrange
+    let test_app: TestApp = spawn_app().await;
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+
+    // create user for testing
+    let mut test_app_response = test_app.create_new_test_user().await;
+    assert!(test_app_response.status().is_success());
+    // log in user
+    test_app_response = test_app.log_in_test_user().await;
+    assert!(test_app_response.status().is_success());
+
+    // Create Quiz as Test User
+    let info: serde_json::Value = serde_json::json!({
+        "name": "Algorithms",
+        "description": "An algorithms quiz"
+    });
+    let response: Response = test_app.post_create_quiz(&info).await;
+    assert!(response.status().is_success());
+    let quiz: SurrealQuiz = response.json().await.unwrap();
+
+    // Setting up query param
+    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+
+    let log_out_response: Response = test_app
+        .api_client
+        .get(format!("{}/user-logout", &test_app.address))
+        .send()
+        .await
+        .expect("Failed to send log out request");
+    assert!(log_out_response.status().is_success());
+
+    // Act
+    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    assert!(test_res.status().as_u16() == 403);
+
+    // Assert
+    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    assert!(1 == actual.len());
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+}
+
+#[tokio::test]
+async fn test_other_user_delete_quiz_403() {
+    // -- Arrange
+    let test_app: TestApp = spawn_app().await;
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+
+    // Test User Data
+    let user_data: Value = serde_json::json!({
+        "name": "Dummy",
+        "username": "dummy123",
+        "password": "Password@1234"
+    });
+
+    // Creating User via API
+    let response01: Response = test_app
+        .api_client
+        .post(&format!("{}/create-user", &test_app.address))
+        .json(&user_data)
+        .send()
+        .await
+        .expect("Failed to create user");
+    assert!(response01.status().is_success());
+
+    let login_data: Value = serde_json::json!({
+        "username": "testuser123",
+        "password": "Password@1234"
+    });
+
+    // Send Login Request
+    let response02: Response = test_app
+        .api_client
+        .post(&format!("{}/user-login", &test_app.address))
+        .json(&login_data)
+        .send()
+        .await
+        .expect("Failed to send login data");
+    assert!(response02.status().is_success());
+
+    // Create Quiz as Dummy User
+    let info: serde_json::Value = serde_json::json!({
+        "name": "Algorithms",
+        "description": "An algorithms quiz"
+    });
+    let response: Response = test_app.post_create_quiz(&info).await;
+    assert!(response.status().is_success());
+    let quiz: SurrealQuiz = response.json().await.unwrap();
+
+    // Setting up query param
+    let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+
+    let log_out_response: Response = test_app
+        .api_client
+        .get(format!("{}/user-logout", &test_app.address))
+        .send()
+        .await
+        .expect("Failed to send log out request");
+    assert!(log_out_response.status().is_success());
+
+    // create user for testing
+    let mut test_app_response = test_app.create_new_test_user().await;
+    assert!(test_app_response.status().is_success());
+    // log in user
+    test_app_response = test_app.log_in_test_user().await;
+    assert!(test_app_response.status().is_success());
+
+    // Act
+    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    assert!(test_res.status().as_u16() == 403);
+
+    // Assert
+    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    assert!(1 == actual.len());
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+}
+
+#[tokio::test]
+async fn test_create_quiz_400() {
+    // -- Arrange
+    let test_app: TestApp = spawn_app().await;
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+
+    // create user for testing
+    let mut test_app_response = test_app.create_new_test_user().await;
+    assert!(test_app_response.status().is_success());
+    // log in user
+    test_app_response = test_app.log_in_test_user().await;
+    assert!(test_app_response.status().is_success());
+
+    // Quiz Structure - Hopefully no questions starts and empty vector
+    let info: serde_json::Value = serde_json::json!({
+        "name": "Algorithms",
+        "description": "An algorithms quiz"
+    });
+    let response: Response = test_app.post_create_quiz(&info).await;
+    assert!(response.status().is_success());
+    // let quiz: SurrealQuiz = response.json().await.unwrap();
+
+    // Setting up query param
+    // let query_param: String = urlencoding::encode(&quiz.id.to_raw()).to_string();
+    let query_param: String = urlencoding::encode("quizzes:not-real-id-123").to_string();
+
+    // Act
+    let test_res: Response = test_app.destroy_quiz(query_param).await;
+    assert!(test_res.status().as_u16() == 200);
+
+    // Assert
+    let actual: Vec<SurrealQuiz> = test_app.database.client.select("quizzes").await.unwrap();
+    assert!(1 > actual.len());
+
+    // clean up database
+    let _: Vec<SurrealRecord> = test_app.database.client.delete("quizzes").await.unwrap();
+    // Clear out users
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("general_user").await;
+    // Clear out session tokens
+    let _: surrealdb::Result<Vec<Thing>> = test_app.database.client.delete("sessions").await;
+}

--- a/backend/tests/api/get_questions.rs
+++ b/backend/tests/api/get_questions.rs
@@ -116,8 +116,8 @@ async fn test_get_questions_200() {
 
     // Assert
     assert!(res.status() == 200);
-    let actual: Vec<SurrealQuestionMC> = res.json().await.unwrap();
-    assert!(actual.len() == 3);
+    let everything: AllQuestions = res.json().await.unwrap();
+    assert!(everything.mc.len() == 3);
 
     // dbg!(this);
     // TODO: Also want to compare `response.json().await` to database query.

--- a/backend/tests/api/get_questions.rs
+++ b/backend/tests/api/get_questions.rs
@@ -31,7 +31,6 @@ async fn test_get_questions_200() {
         test_app_response.status().is_success(),
         "Failed to log user in"
     );
-    // let client: Client = Client::new();
 
     // Quiz Structure
     let info: serde_json::Value = serde_json::json!({

--- a/backend/tests/api/get_quiz.rs
+++ b/backend/tests/api/get_quiz.rs
@@ -57,7 +57,7 @@ async fn test_get_quiz_200() {
     // Make a quiz
     let quiz_info2: serde_json::Value = serde_json::json!({
         "name": "Rust",
-        "description": "An Rust quiz"
+        "description": "A Rust quiz"
     });
 
     let response: Response = test_app.post_create_quiz(&quiz_info2).await;

--- a/backend/tests/api/main.rs
+++ b/backend/tests/api/main.rs
@@ -4,6 +4,7 @@
 mod create_questions;
 mod create_quiz;
 mod create_user;
+mod destroy_question;
 mod destroy_quiz;
 mod get_questions;
 mod get_quiz;

--- a/backend/tests/api/main.rs
+++ b/backend/tests/api/main.rs
@@ -4,6 +4,7 @@
 mod create_questions;
 mod create_quiz;
 mod create_user;
+mod destroy_quiz;
 mod get_questions;
 mod get_quiz;
 mod health_check;

--- a/backend/tests/api/utils.rs
+++ b/backend/tests/api/utils.rs
@@ -117,7 +117,7 @@ pub trait DestroyQuestion {
 impl DestroyQuestion for TestApp {
     async fn destroy_question(&self, quest_id: String) -> Response {
         self.api_client
-            .get(&format!(
+            .delete(&format!(
                 "{}/question-forge?quest={}",
                 &self.address, quest_id
             ))

--- a/backend/tests/api/utils.rs
+++ b/backend/tests/api/utils.rs
@@ -110,6 +110,23 @@ impl GetQuestion for TestApp {
     }
 }
 
+pub trait DestroyQuestion {
+    fn destroy_question(&self, quest_id: String) -> impl Future<Output = Response>;
+}
+
+impl DestroyQuestion for TestApp {
+    async fn destroy_question(&self, quest_id: String) -> Response {
+        self.api_client
+            .get(&format!(
+                "{}/question-forge?quest={}",
+                &self.address, quest_id
+            ))
+            .send()
+            .await
+            .expect("Failed to execute GET Request")
+    }
+}
+
 /// Some helper function for the `TestApp`
 /// Be sure to initialize an instance with `spawn_app()` before using these methods.
 impl TestApp {

--- a/backend/tests/api/utils.rs
+++ b/backend/tests/api/utils.rs
@@ -58,6 +58,20 @@ impl GetQuiz for TestApp {
     }
 }
 
+pub trait DestroyQuiz {
+    async fn destroy_quiz(&self, quiz_id: String) -> Response;
+}
+
+impl DestroyQuiz for TestApp {
+    async fn destroy_quiz(&self, quiz_id: String) -> Response {
+        self.api_client
+            .delete(&format!("{}/quiz-nexus?quiz={}", &self.address, quiz_id))
+            .send()
+            .await
+            .expect("Failed to execute GET Request")
+    }
+}
+
 pub trait CreateQuestions<Body>
 where
     Body: serde::Serialize,
@@ -99,9 +113,9 @@ impl GetQuestion for TestApp {
 /// Some helper function for the `TestApp`
 /// Be sure to initialize an instance with `spawn_app()` before using these methods.
 impl TestApp {
+    // TODO: Maybe make into Builder like function to take in credentials or default
     /// Assuming user not created, Cleans out test database and creates a new test user.
     pub async fn create_new_test_user(&self) -> Response {
-        dbg!(String::from("Cquiz.id.to_string()learing database"));
         // Clear out users
         let _: surrealdb::Result<Vec<Thing>> = self.database.client.delete("general_user").await;
         // Clear out session tokens

--- a/frontend/src/components/dashboard/create_questions.rs
+++ b/frontend/src/components/dashboard/create_questions.rs
@@ -2,8 +2,10 @@
 //! This component will handle the initial question making procecss
 use crate::{
     components::dashboard::{QuestionMold, QuestionShowcase},
-    models::mimic_surreal::SurrealQuiz,
-    models::questions::{JsonQuestion, QLInternals, Quest, QuestType},
+    models::{
+        mimic_surreal::{SurrealQuestionMC, SurrealQuiz},
+        questions::{JsonQuestion, QLInternals, Quest, QuestType},
+    },
     utils::DashDisplay,
 };
 use leptos::*;
@@ -46,6 +48,9 @@ pub fn QuestionForge(
             *val = *val + 1;
         });
     });
+    let remove_quest_mc: Callback<QuestType> = Callback::new(move |dead_quest: QuestType| {
+        quest_signal.update(|this| this.retain(|qst| qst.quest.get_id() != dead_quest.get_id()));
+    });
 
     view! {
         <>
@@ -57,6 +62,7 @@ pub fn QuestionForge(
                 children=move |thing| view!{
                     <QuestionShowcase
                         quest=thing
+                        pop_quest=remove_quest_mc
                     />
                 }
             />
@@ -76,6 +82,3 @@ pub fn QuestionForge(
         </>
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/frontend/src/components/dashboard/display_questions.rs
+++ b/frontend/src/components/dashboard/display_questions.rs
@@ -3,13 +3,16 @@
 use crate::{
     models::mimic_surreal::SurrealQuestionMC,
     models::questions::{Quest, QuestType},
+    store::AppSettings,
+    utils::Fetcher,
 };
 use leptos::*;
+use web_sys::{Headers, RequestMode, Response};
 
 /// Component to display questions, for review or to be edited.
 /// This component should not perform the editing.
 #[component]
-pub fn QuestionShowcase(quest: Quest) -> impl IntoView {
+pub fn QuestionShowcase(quest: Quest, pop_quest: Callback<QuestType>) -> impl IntoView {
     // -- Create Signals
     // Probably need a signal to change between Exhibit and Calibrate
     let tomorrow: i32 = 0;
@@ -17,7 +20,7 @@ pub fn QuestionShowcase(quest: Quest) -> impl IntoView {
     // -- Call backs --
     if let 0 = tomorrow {
         match quest.quest {
-            QuestType::MC(data) => view! {<QuestionExhibitMC data=data />},
+            QuestType::MC(data) => view! {<QuestionExhibitMC data=data pop_quest=pop_quest/>},
             _ => view! {<Unimplemented />},
         }
     } else {
@@ -31,21 +34,52 @@ fn Unimplemented() -> impl IntoView {
 }
 
 #[component]
-pub fn QuestionExhibitMC(data: SurrealQuestionMC) -> impl IntoView {
+pub fn QuestionExhibitMC(data: SurrealQuestionMC, pop_quest: Callback<QuestType>) -> impl IntoView {
+    // -- Create Signals --
+    let quest_signal: RwSignal<SurrealQuestionMC> = create_rw_signal(data);
+
+    // -- Use Context --
+    let app_settings: AppSettings =
+        use_context::<AppSettings>().expect("AppSettings context not found");
+
+    // -- Create Actions --
+    let destroy_quest_action = create_action(move |_| {
+        let headers: Headers = Headers::new().unwrap();
+        headers
+            .set("Content-Type", "application/json;charset=UTF-8")
+            .unwrap();
+        let fetcher: Fetcher = Fetcher::init()
+            .set_url(app_settings.backend_url.to_string() + "question-forge")
+            .add_query_param("quest", &quest_signal.get().id.to_raw())
+            .set_method("DELETE")
+            .set_headers(headers)
+            .set_mode(RequestMode::Cors)
+            .build();
+        async move {
+            let response: Response = fetcher.fetch(None).await;
+            if response.status() == 200 {
+                let del_quest: SurrealQuestionMC = Fetcher::response_to_struct(&response).await;
+                pop_quest.call(QuestType::MC(del_quest));
+            }
+        }
+    });
     view! {
         <div>
-            <p>"Q: "{data.question}</p>
-            <p>"Hint: "{data.hint}</p>
-            <p>"A: "{data.answer}</p>
+            <p>"Q: "{move || quest_signal.get().question}</p>
+            <p>"Hint: "{move || quest_signal.get().hint}</p>
+            <p>"A: "{move || quest_signal.get().answer}</p>
             <For
-                each=move || data.choices.clone()
+                each=move || quest_signal.get().choices.clone()
                 key=|this| this.bytes().fold(0u32, |sum, byte| sum.wrapping_add(byte as u32))
                 children=move |it| view! {
                     <p>"Wrong: "{it}</p>
                 }
             />
             <button>"Edit"</button>
-            <button>"Delete"</button>
+            <button
+                data-note="delete_quest_button"
+                on:click=move |_| destroy_quest_action.dispatch(())
+            >"Delete"</button>
         </div>
     }
 }

--- a/frontend/src/components/dashboard/get_quiz.rs
+++ b/frontend/src/components/dashboard/get_quiz.rs
@@ -2,15 +2,14 @@
 //! This component will handle quiz making logic and pass
 //! user to the making questions screen.
 use leptos::*;
-use leptos_dom::logging::console_log;
 use serde::{Deserialize, Serialize};
 use web_sys::{Headers, RequestMode, Response};
 
 use crate::{
     components::Card,
     models::mimic_surreal::{SurrealQuiz, Thing},
-    store::{AppSettings, AuthState},
-    utils::{DashDisplay, Fetcher, JsonMsg, PartialUser},
+    store::AppSettings,
+    utils::Fetcher,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -71,7 +70,6 @@ pub fn QuizExhibit(
 
     // -- Create Actions --
     let destroy_quiz_action = create_action(move |_| {
-        console_log(&quiz_sig.get().id.to_raw());
         let headers: Headers = Headers::new().unwrap();
         headers
             .set("Content-Type", "application/json;charset=UTF-8")
@@ -96,11 +94,14 @@ pub fn QuizExhibit(
         <Card on_click=None>
             <p>"Name: "{move || quiz_sig.get().name}</p>
             <p>{move || quiz_sig.get().description}</p>
-            <button data-note="unimplemented" on:click=take_quiz_closure>"Take Quiz"</button>
+            <button
+                data-note="take_quiz_button"
+                on:click=take_quiz_closure
+            >"Take Quiz"</button>
             <button data-note="unimplemented">"Edit"</button>
             <button data-note="unimplemented">"Calibrate"</button>
             <button
-                data-note="unimplemented"
+                data-note="delete_quiz_button"
                 on:click=move |_| destroy_quiz_action.dispatch(())
             >"Delete Quiz"</button>
         </Card>

--- a/frontend/src/components/dashboard/get_quiz.rs
+++ b/frontend/src/components/dashboard/get_quiz.rs
@@ -2,6 +2,7 @@
 //! This component will handle quiz making logic and pass
 //! user to the making questions screen.
 use leptos::*;
+use leptos_dom::logging::console_log;
 use serde::{Deserialize, Serialize};
 use web_sys::{Headers, RequestMode, Response};
 
@@ -68,20 +69,16 @@ pub fn QuizExhibit(
         quiz_selector.call(quiz_sig.get());
     };
 
-    // Action To destroy Quiz
-    let destroy_quiz_closure = move |_| {
-        quiz_selector.call(quiz_sig.get());
-    };
-
     // -- Create Actions --
-    let destroy_quiz_action = create_action(move |quiz_id: &String| {
+    let destroy_quiz_action = create_action(move |_| {
+        console_log(&quiz_sig.get().id.to_raw());
         let headers: Headers = Headers::new().unwrap();
         headers
             .set("Content-Type", "application/json;charset=UTF-8")
             .unwrap();
         let fetcher: Fetcher = Fetcher::init()
             .set_url(app_settings.backend_url.to_string() + "quiz-nexus")
-            .add_query_param("quiz", &quiz_id)
+            .add_query_param("quiz", &quiz_sig.get().id.to_raw())
             .set_method("DELETE")
             .set_headers(headers)
             .set_mode(RequestMode::Cors)
@@ -102,7 +99,10 @@ pub fn QuizExhibit(
             <button data-note="unimplemented" on:click=take_quiz_closure>"Take Quiz"</button>
             <button data-note="unimplemented">"Edit"</button>
             <button data-note="unimplemented">"Calibrate"</button>
-            <button data-note="unimplemented" on:click=destroy_quiz_closure>"Delete Quiz"</button>
+            <button
+                data-note="unimplemented"
+                on:click=move |_| destroy_quiz_action.dispatch(())
+            >"Delete Quiz"</button>
         </Card>
     }
 }

--- a/frontend/src/components/dashboard/get_quiz.rs
+++ b/frontend/src/components/dashboard/get_quiz.rs
@@ -1,9 +1,16 @@
 //! frontend/src/components/dashboard/get_quiz.rs
 //! This component will handle quiz making logic and pass
 //! user to the making questions screen.
-use crate::{components::Card, models::mimic_surreal::SurrealQuiz};
 use leptos::*;
 use serde::{Deserialize, Serialize};
+use web_sys::{Headers, RequestMode, Response};
+
+use crate::{
+    components::Card,
+    models::mimic_surreal::{SurrealQuiz, Thing},
+    store::{AppSettings, AuthState},
+    utils::{DashDisplay, Fetcher, JsonMsg, PartialUser},
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QuizJsonPkg {
@@ -15,6 +22,7 @@ pub struct QuizJsonPkg {
 pub fn QuizShowCase(
     quiz_list: RwSignal<Vec<SurrealQuiz>>,
     quiz_selector: Callback<SurrealQuiz>,
+    pop_quiz: Callback<SurrealQuiz>,
 ) -> impl IntoView {
     //  -- Create Signals --
     //  -- Create References --
@@ -34,6 +42,7 @@ pub fn QuizShowCase(
                     <QuizExhibit
                         surreal_quiz=this
                         quiz_selector=quiz_selector
+                        pop_quiz=pop_quiz
                     />
                 }
             />
@@ -45,19 +54,55 @@ pub fn QuizShowCase(
 pub fn QuizExhibit(
     surreal_quiz: SurrealQuiz,
     quiz_selector: Callback<SurrealQuiz>,
+    pop_quiz: Callback<SurrealQuiz>,
 ) -> impl IntoView {
-    let mut cloned_quiz = surreal_quiz.clone();
+    // -- Create Signals --
+    let quiz_sig: RwSignal<SurrealQuiz> = create_rw_signal(surreal_quiz);
+
+    // -- Use Context --
+    let app_settings: AppSettings =
+        use_context::<AppSettings>().expect("AppSettings context not found");
+
+    // -- Create Closures
     let take_quiz_closure = move |_| {
-        quiz_selector.call(cloned_quiz.clone());
+        quiz_selector.call(quiz_sig.get());
     };
+
+    // Action To destroy Quiz
+    let destroy_quiz_closure = move |_| {
+        quiz_selector.call(quiz_sig.get());
+    };
+
+    // -- Create Actions --
+    let destroy_quiz_action = create_action(move |quiz_id: &String| {
+        let headers: Headers = Headers::new().unwrap();
+        headers
+            .set("Content-Type", "application/json;charset=UTF-8")
+            .unwrap();
+        let fetcher: Fetcher = Fetcher::init()
+            .set_url(app_settings.backend_url.to_string() + "quiz-nexus")
+            .add_query_param("quiz", &quiz_id)
+            .set_method("DELETE")
+            .set_headers(headers)
+            .set_mode(RequestMode::Cors)
+            .build();
+        async move {
+            let response: Response = fetcher.fetch(None).await;
+            if response.status() == 200 {
+                let del_quiz: SurrealQuiz = Fetcher::response_to_struct(&response).await;
+                pop_quiz.call(del_quiz);
+            }
+        }
+    });
+
     view! {
         <Card on_click=None>
-            <p>"Name: "{surreal_quiz.name}</p>
-            <p>{surreal_quiz.description}</p>
+            <p>"Name: "{move || quiz_sig.get().name}</p>
+            <p>{move || quiz_sig.get().description}</p>
             <button data-note="unimplemented" on:click=take_quiz_closure>"Take Quiz"</button>
             <button data-note="unimplemented">"Edit"</button>
             <button data-note="unimplemented">"Calibrate"</button>
-            <button data-note="unimplemented">"Delete Quiz"</button>
+            <button data-note="unimplemented" on:click=destroy_quiz_closure>"Delete Quiz"</button>
         </Card>
     }
 }

--- a/frontend/src/components/dashboard/question_types.rs
+++ b/frontend/src/components/dashboard/question_types.rs
@@ -161,7 +161,7 @@ pub fn QuestionCastMC(
 
     view! {
         <form on:submit=on_submit>
-            <h4>"don't give up"</h4>
+            <h4>"new question"</h4>
             <h4>{move || err_msg.get() }</h4>
             <input type="text" placeholder="question" node_ref=question_ref required/>
             <input type="text" placeholder="hint" node_ref=hint_ref/>

--- a/frontend/src/models/mimic_surreal.rs
+++ b/frontend/src/models/mimic_surreal.rs
@@ -45,5 +45,5 @@ pub struct SurrealQuiz {
     pub name: String,
     pub description: String,
     pub author_id: String,
-    pub questions_mc: Vec<Thing>,
+    // pub questions_mc: Vec<Thing>,
 }

--- a/frontend/src/models/questions.rs
+++ b/frontend/src/models/questions.rs
@@ -19,6 +19,15 @@ pub enum QuestType {
     SA,
 }
 
+impl QuestType {
+    pub fn get_id(&self) -> Thing {
+        match &self {
+            QuestType::MC(quest) => quest.id.clone(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
 /// Struct for allowing Quests to be rendered by <For />
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Quest {

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -59,6 +59,8 @@ pub fn Dashboard() -> impl IntoView {
         ReadSignal<Option<SurrealQuiz>>,
         WriteSignal<Option<SurrealQuiz>>,
     ) = create_signal(None);
+    let quiz_list = create_rw_signal(Vec::new());
+
     // -- Use Context --
     let user: PartialUser = use_context().expect("PartialUser Context not set");
     let app_settings: AppSettings =
@@ -80,7 +82,6 @@ pub fn Dashboard() -> impl IntoView {
     // TODO: Make request for current tests
     // try `create_local_resource`
     // or `create_render_effect`
-    let quiz_list = create_rw_signal(Vec::new());
     // let settings_rc = std::rc::Rc::new(app_settings);
     let quizzes_resource = create_resource(
         || (), // only render once
@@ -113,9 +114,9 @@ pub fn Dashboard() -> impl IntoView {
     let add_quiz = move |new_quiz: SurrealQuiz| {
         quiz_list.update(|quizzes| quizzes.push(new_quiz));
     };
-    let remove_quiz = move |dead_quiz: SurrealQuiz| {
+    let remove_quiz: Callback<SurrealQuiz> = Callback::new(move |dead_quiz: SurrealQuiz| {
         quiz_list.update(|q| q.retain(|qz| qz.id != dead_quiz.id));
-    };
+    });
     create_effect(move |_| {
         // if let Some(Ok(fetched_quizzes)) = quizzes_resource.get() {
         //     quiz_list.set(fetched_quizzes);
@@ -129,6 +130,7 @@ pub fn Dashboard() -> impl IntoView {
                 <QuizShowCase
                     quiz_list=quiz_list
                     quiz_selector=choose_quiz_to_take
+                    pop_quiz=remove_quiz
                 />
             </>
         },
@@ -145,7 +147,6 @@ pub fn Dashboard() -> impl IntoView {
         },
         DashDisplay::TakeQuiz => view! {
             <>
-                <h3>"I Love quizzes"</h3>
                 <ExamRoom some_quiz=current_quiz_rw.get()/>
             </>
         },

--- a/models/src/questions.rs
+++ b/models/src/questions.rs
@@ -5,6 +5,16 @@ use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Id, Thing};
 use surrealize_macro::Surrealize;
 
+/// Currently for deleting questions generically
+/// All questions must have this Generic Data to be processed correctly
+/// in all endpoints.
+#[derive(Serialize, Deserialize, Debug, Surrealize)]
+pub struct GenericQuestionData {
+    pub question: String,
+    pub author_id: String,
+    pub parent_quiz: Thing,
+}
+
 // pub struct QuestionType {}
 pub enum QuestionType {
     MultipleChoice(QuestionMC),

--- a/models/src/quiz.rs
+++ b/models/src/quiz.rs
@@ -1,7 +1,6 @@
 //! models/src/quiz.rs
 use crate::model_errors::ModelErrors;
 use serde::{Deserialize, Serialize};
-use surrealdb::sql::Thing;
 use surrealize_macro::Surrealize;
 
 #[derive(Serialize, Deserialize, Debug, Surrealize)]
@@ -9,7 +8,6 @@ pub struct Quiz {
     pub name: String,
     pub description: String,
     pub author_id: String,
-    pub questions_mc: Vec<Thing>,
 }
 
 impl Quiz {
@@ -18,7 +16,6 @@ impl Quiz {
             name,
             description,
             author_id,
-            questions_mc: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Part of story for issue #16 these features delete Quiz and Questions from the database and some implementation for the front-end also. I also removed the Quiz's knowledge of its Question children in the database. Implementing this was becoming difficult and clumsy, and did not provide any benefit. 