### PR TITLE
ISSUE-33: Quiz Populate on Homepage

### DIFF
--- a/backend/src/routes/destroy_quiz.rs
+++ b/backend/src/routes/destroy_quiz.rs
@@ -130,12 +130,15 @@ pub async fn destroy_my_quiz(
     // Delete related questions
 
     // Delete from MC table
-    let surreal_ql = "DELETE type::table($table) WHERE author_id = $user_id";
+    let surreal_ql = r#"DELETE type::table($table)
+    WHERE author_id = $user_id
+    AND parent_quiz = $quiz_id"#;
     let surreal_response: surrealdb::Response = db
         .client
         .query(surreal_ql)
         .bind(("table", "questions_mc"))
         .bind(("user_id", user_id))
+        .bind(("quiz_id", &quiz_id))
         .await
         .map_err(|err| DestroyQuizError::UnexpectedError(anyhow::anyhow!(err)))?;
 

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -64,7 +64,7 @@ button, input[type="submit"]{
       align-items: flex-start;
     }
     a:link {
-      color: #dAdAfA;
+      color: #5AdAfA;
     }
     a:visited {
       color: #eA3AAA;

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -34,6 +34,26 @@ button, input[type="submit"]{
   cursor: pointer;
 }
 
+h1 {
+  font-size: 2rem;
+}
+h2 {
+  font-size: 1.8rem;
+}
+h3 {
+  font-size: 1.6rem;
+}
+h4 {
+  font-size: 1.4rem;
+  margin: 0.5rem;
+}
+h5 {
+  font-size: 1.2rem;
+}
+h6 {
+  font-size: 1rem;
+}
+
 
 /* -- Signin / Login -- */
 .form-card-container {
@@ -163,7 +183,7 @@ footer {
   flex: 1;
   border: 0.25rem solid black;
   border-radius: 1rem;
-  padding: 3rem;
+  padding: 2rem;
   margin: 1rem;
   /* overflow-y: auto; */
   display: flex;
@@ -210,6 +230,38 @@ footer {
     filter: brightness(1.3);
   }
 }
+
+/* --- Question Create and Edit --- */
+.forge-container {
+  border: red dashed 3px;
+  border-radius: .8rem;
+  box-shadow: 0 0 1rem 0.3rem #00000088;
+  width: 100%;
+  padding: 1rem 2rem;
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  margin-bottom: 0.5rem;
+
+  input[type="text"] {
+    width: 100%;
+    padding: 0.3rem;
+    margin: 0.3rem;
+    border-radius: 5px;
+  }
+}
+
+.button-case {
+  width: 100%;
+  max-width: 20rem;
+  display: flex;
+  flex-flow: row;
+  justify-content: space-around;
+}
+
+/* --- ------------------------ --- */
 
 /* -- Quiz Styling -- */
 .quiz-showcase-container {

--- a/frontend/src/components/dashboard/edit_questions.rs
+++ b/frontend/src/components/dashboard/edit_questions.rs
@@ -113,7 +113,10 @@ pub fn QuestionCalibrateMC(
     };
 
     view! {
-        <form on:submit=on_submit>
+        <form
+            class="forge-container"
+            on:submit=on_submit
+        >
             <h4>"Question Calibration"</h4>
             <h4>{move || err_msg.get() }</h4>
             <input
@@ -155,8 +158,12 @@ pub fn QuestionCalibrateMC(
                 value=move || quest_sig.get().choices[2].clone()
                 required
             />
-            <input type="submit" value="Save" />
-            <button on:click=move |_| cancel_edit.call(())>"Cancel"</button>
+            <div
+                class="button-case"
+            >
+                <input type="submit" value="Save" />
+                <button on:click=move |_| cancel_edit.call(())>"Cancel"</button>
+            </div>
         </form>
     }
 }

--- a/frontend/src/components/dashboard/make_quiz.rs
+++ b/frontend/src/components/dashboard/make_quiz.rs
@@ -20,6 +20,7 @@ pub struct QuizJsonPkg {
 pub fn MakeQuiz(
     display_settings: WriteSignal<DashDisplay>,
     response_setter: WriteSignal<Option<SurrealQuiz>>,
+    push_quiz: Callback<SurrealQuiz>,
 ) -> impl IntoView {
     //  -- Create Signals --
     let (err_msg, set_err_msg): (ReadSignal<Option<String>>, WriteSignal<Option<String>>) =
@@ -48,6 +49,7 @@ pub fn MakeQuiz(
             let response: Response = fetcher.fetch(Some(pkg_clone)).await;
             if response.status() == 200 {
                 let data: SurrealQuiz = Fetcher::response_to_struct(&response).await;
+                push_quiz.call(data.clone());
                 response_setter.set(Some(data));
                 display_settings.set(DashDisplay::MakeQuestions);
             } else {

--- a/frontend/src/components/dashboard/question_types.rs
+++ b/frontend/src/components/dashboard/question_types.rs
@@ -158,7 +158,10 @@ pub fn QuestionCastMC(
     };
 
     view! {
-        <form on:submit=on_submit>
+        <form
+            class="quest-case"
+            on:submit=on_submit
+        >
             <h4>"New Question"</h4>
             <h4>{move || err_msg.get() }</h4>
             <input type="text" placeholder="question" node_ref=question_ref required/>

--- a/frontend/src/components/dashboard/question_types.rs
+++ b/frontend/src/components/dashboard/question_types.rs
@@ -18,7 +18,9 @@ pub fn QuestionMold(
     quiz_data: ReadSignal<Option<SurrealQuiz>>,
 ) -> impl IntoView {
     view! {
-        <div>
+        <div
+            style="width: 100%"
+        >
             <p>"Only Multiple Choice at the moment"</p>
             {move || {
                 match question.data {
@@ -159,7 +161,7 @@ pub fn QuestionCastMC(
 
     view! {
         <form
-            class="quest-case"
+            class="forge-container"
             on:submit=on_submit
         >
             <h4>"New Question"</h4>

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -150,7 +150,13 @@ pub fn Dashboard() -> impl IntoView {
             </>
         },
         DashDisplay::MakeQuizzes => view! {
-            <><MakeQuiz display_settings=write_display response_setter=set_quiz_data/></>
+            <>
+                <MakeQuiz
+                    display_settings=write_display
+                    response_setter=set_quiz_data
+                    push_quiz=add_quiz
+                />
+            </>
         },
         DashDisplay::MakeQuestions => view! {
             <>


### PR DESCRIPTION
When the user made a new quiz, following issue #33 , it wouldn't automatically populate on the homepage. This PR addresses that with adding the quiz to a list that tracks user quizzes.

Also found a small bug where when the user deletes a quiz all the questions for the user are deleted. The Surreal QL statement was deleting all questions from the user and not from the deleted quiz. This issue is also fixed.

Also enhanced some CSS. 